### PR TITLE
Scale platform to 50 kitchens across 10 Texas cities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ _delta_log/
 
 # Docker volumes
 data/
+!data/seed/
 logs/
 
 # IDE

--- a/data/seed/brands.csv
+++ b/data/seed/brands.csv
@@ -1,0 +1,9 @@
+brand_id,brand_name,cuisine_type,launch_date,is_active
+BB,Burger Beast,American,2020-06-01,TRUE
+DW,Dragon Wok,Chinese,2020-08-15,TRUE
+PP,Pizza Planet,Italian,2021-01-10,TRUE
+TT,Taco Tornado,Mexican,2021-03-01,TRUE
+SS,Sushi Storm,Japanese,2021-07-20,TRUE
+PA,Pasta Palace,Italian,2022-01-15,TRUE
+BQ,BBQ Barn,American,2022-04-10,TRUE
+SL,Salad Studio,American,2022-09-01,TRUE

--- a/data/seed/kitchens.csv
+++ b/data/seed/kitchens.csv
@@ -1,0 +1,51 @@
+kitchen_id,name,city,state,lat,lon,capacity_orders_per_hour,opened_date,is_active
+K-HOU-01,GhostKitchen Houston Central,Houston,Texas,29.7604,-95.3698,15,2022-03-01,TRUE
+K-HOU-02,GhostKitchen Houston Heights,Houston,Texas,29.7979,-95.3970,12,2022-07-15,TRUE
+K-HOU-03,GhostKitchen Houston Galleria,Houston,Texas,29.7369,-95.4613,18,2023-01-20,TRUE
+K-HOU-04,GhostKitchen Houston Midtown,Houston,Texas,29.7390,-95.3840,14,2023-04-01,TRUE
+K-HOU-05,GhostKitchen Houston Katy,Houston,Texas,29.7858,-95.8245,10,2023-09-01,TRUE
+K-DAL-01,GhostKitchen Dallas Uptown,Dallas,Texas,32.7935,-96.8026,15,2022-05-01,TRUE
+K-DAL-02,GhostKitchen Dallas Deep Ellum,Dallas,Texas,32.7838,-96.7854,12,2022-11-01,TRUE
+K-DAL-03,GhostKitchen Dallas North,Dallas,Texas,32.8700,-96.7700,16,2023-02-14,TRUE
+K-DAL-04,GhostKitchen Dallas Oak Lawn,Dallas,Texas,32.8093,-96.8172,13,2023-06-01,TRUE
+K-DAL-05,GhostKitchen Dallas Frisco,Dallas,Texas,33.1507,-96.8236,14,2023-10-01,TRUE
+K-AUS-01,GhostKitchen Austin Downtown,Austin,Texas,30.2672,-97.7431,18,2021-11-01,TRUE
+K-AUS-02,GhostKitchen Austin East Side,Austin,Texas,30.2584,-97.7198,15,2022-04-01,TRUE
+K-AUS-03,GhostKitchen Austin South Congress,Austin,Texas,30.2270,-97.7524,12,2022-09-01,TRUE
+K-AUS-04,GhostKitchen Austin North Loop,Austin,Texas,30.3500,-97.7200,16,2023-03-01,TRUE
+K-AUS-05,GhostKitchen Austin Buda,Austin,Texas,30.0850,-97.8400,10,2023-08-01,TRUE
+K-SAT-01,GhostKitchen San Antonio Downtown,San Antonio,Texas,29.4241,-98.4936,10,2023-01-10,TRUE
+K-SAT-02,GhostKitchen San Antonio Alamo,San Antonio,Texas,29.4258,-98.4861,12,2023-03-01,TRUE
+K-SAT-03,GhostKitchen San Antonio Pearl,San Antonio,Texas,29.4489,-98.4802,14,2023-05-15,TRUE
+K-SAT-04,GhostKitchen San Antonio Medical,San Antonio,Texas,29.5014,-98.5800,11,2023-07-01,TRUE
+K-SAT-05,GhostKitchen San Antonio Stone Oak,San Antonio,Texas,29.6116,-98.4814,13,2024-01-15,TRUE
+K-FTW-01,GhostKitchen Fort Worth Sundance,Fort Worth,Texas,32.7555,-97.3308,15,2022-06-01,TRUE
+K-FTW-02,GhostKitchen Fort Worth Cultural District,Fort Worth,Texas,32.7469,-97.3354,12,2022-10-01,TRUE
+K-FTW-03,GhostKitchen Fort Worth TCU,Fort Worth,Texas,32.7096,-97.3625,14,2023-02-01,TRUE
+K-FTW-04,GhostKitchen Fort Worth Alliance,Fort Worth,Texas,32.9823,-97.3163,11,2023-05-01,TRUE
+K-FTW-05,GhostKitchen Fort Worth Hurst,Fort Worth,Texas,32.8235,-97.1881,10,2023-11-01,TRUE
+K-ELP-01,GhostKitchen El Paso Downtown,El Paso,Texas,31.7619,-106.4850,12,2022-08-01,TRUE
+K-ELP-02,GhostKitchen El Paso UTEP,El Paso,Texas,31.7677,-106.5014,10,2022-12-01,TRUE
+K-ELP-03,GhostKitchen El Paso Westside,El Paso,Texas,31.8357,-106.5573,13,2023-03-01,TRUE
+K-ELP-04,GhostKitchen El Paso Northeast,El Paso,Texas,31.8701,-106.3849,11,2023-06-15,TRUE
+K-ELP-05,GhostKitchen El Paso Eastside,El Paso,Texas,31.7782,-106.3950,10,2023-10-01,TRUE
+K-ARL-01,GhostKitchen Arlington Center,Arlington,Texas,32.7357,-97.1081,14,2022-07-01,TRUE
+K-ARL-02,GhostKitchen Arlington Stadium,Arlington,Texas,32.7473,-97.0945,12,2022-11-15,TRUE
+K-ARL-03,GhostKitchen Arlington UTA,Arlington,Texas,32.7294,-97.1143,11,2023-01-01,TRUE
+K-ARL-04,GhostKitchen Arlington Six Flags,Arlington,Texas,32.7572,-97.0697,13,2023-04-01,TRUE
+K-ARL-05,GhostKitchen Arlington South,Arlington,Texas,32.6963,-97.0983,10,2023-09-15,TRUE
+K-CRP-01,GhostKitchen Corpus Christi Bayfront,Corpus Christi,Texas,27.8006,-97.3964,12,2022-09-01,TRUE
+K-CRP-02,GhostKitchen Corpus Christi South,Corpus Christi,Texas,27.7575,-97.4072,10,2023-01-01,TRUE
+K-CRP-03,GhostKitchen Corpus Christi North,Corpus Christi,Texas,27.8402,-97.4143,11,2023-04-01,TRUE
+K-CRP-04,GhostKitchen Corpus Christi Flour Bluff,Corpus Christi,Texas,27.6985,-97.3601,10,2023-07-01,TRUE
+K-CRP-05,GhostKitchen Corpus Christi Portland,Corpus Christi,Texas,27.8878,-97.3239,9,2023-11-01,TRUE
+K-PLN-01,GhostKitchen Plano Legacy,Plano,Texas,33.0198,-96.6989,16,2022-04-01,TRUE
+K-PLN-02,GhostKitchen Plano Downtown,Plano,Texas,33.0198,-96.7500,14,2022-08-01,TRUE
+K-PLN-03,GhostKitchen Plano Collin Creek,Plano,Texas,33.0300,-96.7500,13,2023-01-15,TRUE
+K-PLN-04,GhostKitchen Plano East,Plano,Texas,33.0400,-96.6200,12,2023-05-01,TRUE
+K-PLN-05,GhostKitchen Plano Allen,Plano,Texas,33.1032,-96.6706,15,2023-09-01,TRUE
+K-LBB-01,GhostKitchen Lubbock Texas Tech,Lubbock,Texas,33.5843,-101.8746,12,2022-10-01,TRUE
+K-LBB-02,GhostKitchen Lubbock Downtown,Lubbock,Texas,33.5779,-101.8552,10,2023-01-01,TRUE
+K-LBB-03,GhostKitchen Lubbock South,Lubbock,Texas,33.5279,-101.8500,11,2023-04-01,TRUE
+K-LBB-04,GhostKitchen Lubbock North,Lubbock,Texas,33.6400,-101.8400,10,2023-07-01,TRUE
+K-LBB-05,GhostKitchen Lubbock Wolfforth,Lubbock,Texas,33.5057,-101.9980,9,2023-11-01,TRUE

--- a/data_generators/gps_generator.py
+++ b/data_generators/gps_generator.py
@@ -18,16 +18,15 @@ import json, time, random, uuid, math
 from datetime import datetime, timedelta
 from kafka import KafkaProducer
 
+import os
+import sys
+sys.path.insert(0, os.path.dirname(__file__))
+from reference_data import GPS_DELIVERY_ZONES as DELIVERY_ZONES  # noqa: E402
+
 KAFKA_BOOTSTRAP = "localhost:9092"
 TOPIC = "delivery_gps"
 PINGS_PER_SECOND = 8
-
-DELIVERY_ZONES = {
-    "HOU-DOWNTOWN": {"center_lat": 29.7604, "center_lon": -95.3698},
-    "HOU-MIDTOWN": {"center_lat": 29.7440, "center_lon": -95.3866},
-    "DAL-DOWNTOWN": {"center_lat": 32.7767, "center_lon": -96.7970},
-    "AUS-DOWNTOWN": {"center_lat": 30.2672, "center_lon": -97.7431},
-}
+# DELIVERY_ZONES imported from reference_data: 50 zones across 10 cities
 
 # Simulate active deliveries
 active_deliveries = {}

--- a/data_generators/order_generator.py
+++ b/data_generators/order_generator.py
@@ -17,9 +17,14 @@ import json
 import time
 import random
 import uuid
+import os
+import sys
 from datetime import datetime, timedelta
 from kafka import KafkaProducer
 from faker import Faker
+
+sys.path.insert(0, os.path.dirname(__file__))
+from reference_data import KITCHENS, CITY_ABBREV  # noqa: E402
 
 fake = Faker()
 
@@ -27,15 +32,6 @@ fake = Faker()
 KAFKA_BOOTSTRAP = "localhost:9092"
 TOPIC = "orders_raw"
 EVENTS_PER_SECOND = 5  # Start slow; increase later
-
-# ── REFERENCE DATA (will become dimensions later) ──
-KITCHENS = [
-    {"kitchen_id": "K-HOU-01", "city": "Houston", "brands": ["Burger Beast", "Dragon Wok", "Pizza Planet"]},
-    {"kitchen_id": "K-HOU-02", "city": "Houston", "brands": ["Taco Tornado", "Sushi Storm"]},
-    {"kitchen_id": "K-DAL-01", "city": "Dallas", "brands": ["Burger Beast", "Pasta Palace"]},
-    {"kitchen_id": "K-AUS-01", "city": "Austin", "brands": ["Dragon Wok", "BBQ Barn", "Salad Studio"]},
-    {"kitchen_id": "K-SAT-01", "city": "San Antonio", "brands": ["Taco Tornado", "Burger Beast"]},
-]
 
 MENU_ITEMS = {
     "Burger Beast": [
@@ -147,9 +143,9 @@ def generate_order_event():
             "currency": "USD",
             "order_status": "placed",
             "order_timestamp": now.isoformat() + "Z",
-            "delivery_zone": f"{kitchen['city'].upper()[:3]}-{zone}",
+            "delivery_zone": f"{CITY_ABBREV[kitchen['city']]}-{zone}",
         }
-    
+
     elif platform == "doordash":
         event = {
             "order_id": order_id,
@@ -162,9 +158,9 @@ def generate_order_event():
             "order_value": total,                        # DoorDash calls it 'order_value'
             "order_status": "placed",
             "created_at": now.isoformat() + "Z",         # DoorDash calls it 'created_at'!
-            "drop_off_zone": f"{kitchen['city'].upper()[:3]}-{zone}",
+            "drop_off_zone": f"{CITY_ABBREV[kitchen['city']]}-{zone}",
         }
-    
+
     else:  # own_app
         event = {
             "order_id": order_id,
@@ -177,7 +173,7 @@ def generate_order_event():
             "amount_cents": int(total * 100),            # OwnApp uses CENTS (integer)!
             "status": "placed",                          # OwnApp calls it just 'status'
             "timestamp": now.isoformat() + "Z",          # OwnApp calls it just 'timestamp'
-            "zone": f"{kitchen['city'].upper()[:3]}-{zone}",
+            "zone": f"{CITY_ABBREV[kitchen['city']]}-{zone}",
         }
     
     # ── INJECT DATA QUALITY ISSUES ──

--- a/data_generators/reference_data.py
+++ b/data_generators/reference_data.py
@@ -1,0 +1,132 @@
+"""
+GhostKitchen — Central Reference Data
+======================================
+Single source of truth for all static platform reference data.
+50 kitchens × 10 Texas cities × 3-5 brands per kitchen.
+
+Import this in every generator so kitchen IDs, brands, and zones
+stay consistent across orders, sensors, GPS, and seed CSVs.
+"""
+
+# ── Brand assignment patterns (3-5 brands per kitchen slot) ──────────────────
+# Pattern index 0 → kitchen suffix 01, etc.  Repeats identically per city.
+_BP = [
+    ["Burger Beast", "Dragon Wok", "Pizza Planet"],                                   # slot 01
+    ["Taco Tornado", "Sushi Storm", "Burger Beast"],                                  # slot 02
+    ["Pasta Palace", "BBQ Barn", "Dragon Wok", "Salad Studio"],                       # slot 03
+    ["Burger Beast", "Pizza Planet", "Taco Tornado", "BBQ Barn"],                     # slot 04
+    ["Dragon Wok", "Sushi Storm", "Pasta Palace", "Salad Studio", "Burger Beast"],    # slot 05
+]
+
+KITCHENS = [
+    # ── Houston ──────────────────────────────────────────────────────────────
+    {"kitchen_id": "K-HOU-01", "city": "Houston",       "brands": _BP[0]},
+    {"kitchen_id": "K-HOU-02", "city": "Houston",       "brands": _BP[1]},
+    {"kitchen_id": "K-HOU-03", "city": "Houston",       "brands": _BP[2]},
+    {"kitchen_id": "K-HOU-04", "city": "Houston",       "brands": _BP[3]},
+    {"kitchen_id": "K-HOU-05", "city": "Houston",       "brands": _BP[4]},
+    # ── Dallas ───────────────────────────────────────────────────────────────
+    {"kitchen_id": "K-DAL-01", "city": "Dallas",        "brands": _BP[0]},
+    {"kitchen_id": "K-DAL-02", "city": "Dallas",        "brands": _BP[1]},
+    {"kitchen_id": "K-DAL-03", "city": "Dallas",        "brands": _BP[2]},
+    {"kitchen_id": "K-DAL-04", "city": "Dallas",        "brands": _BP[3]},
+    {"kitchen_id": "K-DAL-05", "city": "Dallas",        "brands": _BP[4]},
+    # ── Austin ───────────────────────────────────────────────────────────────
+    {"kitchen_id": "K-AUS-01", "city": "Austin",        "brands": _BP[0]},
+    {"kitchen_id": "K-AUS-02", "city": "Austin",        "brands": _BP[1]},
+    {"kitchen_id": "K-AUS-03", "city": "Austin",        "brands": _BP[2]},
+    {"kitchen_id": "K-AUS-04", "city": "Austin",        "brands": _BP[3]},
+    {"kitchen_id": "K-AUS-05", "city": "Austin",        "brands": _BP[4]},
+    # ── San Antonio ──────────────────────────────────────────────────────────
+    {"kitchen_id": "K-SAT-01", "city": "San Antonio",   "brands": _BP[0]},
+    {"kitchen_id": "K-SAT-02", "city": "San Antonio",   "brands": _BP[1]},
+    {"kitchen_id": "K-SAT-03", "city": "San Antonio",   "brands": _BP[2]},
+    {"kitchen_id": "K-SAT-04", "city": "San Antonio",   "brands": _BP[3]},
+    {"kitchen_id": "K-SAT-05", "city": "San Antonio",   "brands": _BP[4]},
+    # ── Fort Worth ───────────────────────────────────────────────────────────
+    {"kitchen_id": "K-FTW-01", "city": "Fort Worth",    "brands": _BP[0]},
+    {"kitchen_id": "K-FTW-02", "city": "Fort Worth",    "brands": _BP[1]},
+    {"kitchen_id": "K-FTW-03", "city": "Fort Worth",    "brands": _BP[2]},
+    {"kitchen_id": "K-FTW-04", "city": "Fort Worth",    "brands": _BP[3]},
+    {"kitchen_id": "K-FTW-05", "city": "Fort Worth",    "brands": _BP[4]},
+    # ── El Paso ──────────────────────────────────────────────────────────────
+    {"kitchen_id": "K-ELP-01", "city": "El Paso",       "brands": _BP[0]},
+    {"kitchen_id": "K-ELP-02", "city": "El Paso",       "brands": _BP[1]},
+    {"kitchen_id": "K-ELP-03", "city": "El Paso",       "brands": _BP[2]},
+    {"kitchen_id": "K-ELP-04", "city": "El Paso",       "brands": _BP[3]},
+    {"kitchen_id": "K-ELP-05", "city": "El Paso",       "brands": _BP[4]},
+    # ── Arlington ────────────────────────────────────────────────────────────
+    {"kitchen_id": "K-ARL-01", "city": "Arlington",     "brands": _BP[0]},
+    {"kitchen_id": "K-ARL-02", "city": "Arlington",     "brands": _BP[1]},
+    {"kitchen_id": "K-ARL-03", "city": "Arlington",     "brands": _BP[2]},
+    {"kitchen_id": "K-ARL-04", "city": "Arlington",     "brands": _BP[3]},
+    {"kitchen_id": "K-ARL-05", "city": "Arlington",     "brands": _BP[4]},
+    # ── Corpus Christi ───────────────────────────────────────────────────────
+    {"kitchen_id": "K-CRP-01", "city": "Corpus Christi","brands": _BP[0]},
+    {"kitchen_id": "K-CRP-02", "city": "Corpus Christi","brands": _BP[1]},
+    {"kitchen_id": "K-CRP-03", "city": "Corpus Christi","brands": _BP[2]},
+    {"kitchen_id": "K-CRP-04", "city": "Corpus Christi","brands": _BP[3]},
+    {"kitchen_id": "K-CRP-05", "city": "Corpus Christi","brands": _BP[4]},
+    # ── Plano ────────────────────────────────────────────────────────────────
+    {"kitchen_id": "K-PLN-01", "city": "Plano",         "brands": _BP[0]},
+    {"kitchen_id": "K-PLN-02", "city": "Plano",         "brands": _BP[1]},
+    {"kitchen_id": "K-PLN-03", "city": "Plano",         "brands": _BP[2]},
+    {"kitchen_id": "K-PLN-04", "city": "Plano",         "brands": _BP[3]},
+    {"kitchen_id": "K-PLN-05", "city": "Plano",         "brands": _BP[4]},
+    # ── Lubbock ──────────────────────────────────────────────────────────────
+    {"kitchen_id": "K-LBB-01", "city": "Lubbock",       "brands": _BP[0]},
+    {"kitchen_id": "K-LBB-02", "city": "Lubbock",       "brands": _BP[1]},
+    {"kitchen_id": "K-LBB-03", "city": "Lubbock",       "brands": _BP[2]},
+    {"kitchen_id": "K-LBB-04", "city": "Lubbock",       "brands": _BP[3]},
+    {"kitchen_id": "K-LBB-05", "city": "Lubbock",       "brands": _BP[4]},
+]
+
+BRANDS = [
+    "Burger Beast", "Dragon Wok", "Pizza Planet", "Taco Tornado",
+    "Sushi Storm", "Pasta Palace", "BBQ Barn", "Salad Studio",
+]
+
+# Zone suffixes — combined with city prefix by generators
+DELIVERY_ZONE_SUFFIXES = ["DOWNTOWN", "MIDTOWN", "UPTOWN", "SUBURBS-N", "SUBURBS-S"]
+
+# City abbreviations used in zone IDs and order events
+CITY_ABBREV = {
+    "Houston":       "HOU",
+    "Dallas":        "DAL",
+    "Austin":        "AUS",
+    "San Antonio":   "SAT",
+    "Fort Worth":    "FTW",
+    "El Paso":       "ELP",
+    "Arlington":     "ARL",
+    "Corpus Christi":"CRP",
+    "Plano":         "PLN",
+    "Lubbock":       "LBB",
+}
+
+# GPS delivery zone centers — one per city × zone (used by gps_generator)
+GPS_DELIVERY_ZONES: dict = {}
+_CITY_CENTERS = {
+    "HOU": (29.7604, -95.3698),
+    "DAL": (32.7767, -96.7970),
+    "AUS": (30.2672, -97.7431),
+    "SAT": (29.4241, -98.4936),
+    "FTW": (32.7555, -97.3308),
+    "ELP": (31.7619, -106.4850),
+    "ARL": (32.7357, -97.1081),
+    "CRP": (27.8006, -97.3964),
+    "PLN": (33.0198, -96.6989),
+    "LBB": (33.5779, -101.8552),
+}
+_ZONE_OFFSETS = {
+    "DOWNTOWN":  (0.000,  0.000),
+    "MIDTOWN":   (-0.015, -0.018),
+    "UPTOWN":    (0.020,  0.010),
+    "SUBURBS-N": (0.060,  0.005),
+    "SUBURBS-S": (-0.060, -0.005),
+}
+for _abbrev, (_clat, _clon) in _CITY_CENTERS.items():
+    for _zone, (_dlat, _dlon) in _ZONE_OFFSETS.items():
+        GPS_DELIVERY_ZONES[f"{_abbrev}-{_zone}"] = {
+            "center_lat": round(_clat + _dlat, 6),
+            "center_lon": round(_clon + _dlon, 6),
+        }

--- a/data_generators/sensor_generator.py
+++ b/data_generators/sensor_generator.py
@@ -30,12 +30,18 @@ from datetime import datetime, timedelta
 from kafka import KafkaProducer
 
 # ── CONFIGURATION ─────────────────────────────────
+import os
+import sys
+sys.path.insert(0, os.path.dirname(__file__))
+from reference_data import KITCHENS as _KITCHEN_DICTS  # noqa: E402
+
 KAFKA_BOOTSTRAP = "localhost:9092"
 TOPIC = "kitchen_sensors"
 EVENTS_PER_SECOND = 15  # Higher velocity than orders — IoT is chatty!
 
 # ── KITCHENS AND THEIR SENSORS ────────────────────
-KITCHENS = ["K-HOU-01", "K-HOU-02", "K-DAL-01", "K-AUS-01", "K-SAT-01"]
+# All 50 kitchen IDs sourced from reference_data (single source of truth)
+KITCHENS = [k["kitchen_id"] for k in _KITCHEN_DICTS]
 
 # Each kitchen has these sensor zones
 SENSOR_CONFIGS = [


### PR DESCRIPTION
## Summary
- Add `data_generators/reference_data.py` as single source of truth: 50 kitchens × 10 Texas cities × 3-5 brands, 50 GPS delivery zones
- Update `order_generator`, `sensor_generator`, `gps_generator` to import from reference_data
- Fix zone abbreviation for multi-word cities (San Antonio→SAT, Fort Worth→FTW, Corpus Christi→CRP)
- Expand `data/seed/kitchens.csv` (5→50 rows) with lat, lon, capacity, opened_date
- Expand `data/seed/brands.csv` with brand_id and launch_date
- Update `.gitignore` to unblock `data/seed/` from the `data/` ignore rule

## Test plan
- [ ] Run `python data_generators/order_generator.py` — confirm orders from all 50 kitchens appear
- [ ] Run `python data_generators/sensor_generator.py` — confirm 50 kitchen IDs in output
- [ ] Run `python data_generators/gps_generator.py` — confirm 50 delivery zones used
- [ ] Check `data/seed/kitchens.csv` has 50 rows, all 10 cities present

Relates to #4 — gps_generator now uses all 50 delivery zones; Bronze GPS ingestion job tracked separately in #4