### PR TITLE
Add Airflow DAGs for full pipeline orchestration

### DIFF
--- a/airflow_dags/dag_bronze_to_silver.py
+++ b/airflow_dags/dag_bronze_to_silver.py
@@ -1,0 +1,82 @@
+"""
+GhostKitchen: Bronze → Silver Airflow DAG
+==========================================
+Runs all Silver transformation scripts in dependency order.
+Schedule: every 2 hours (set to None for dev — trigger manually).
+
+Task order:
+  1. order_schema_alignment (parse + dedup + normalize orders)
+  2. data_vault_loader       (depends on step 1 — loads hub/sat)
+  3. menu_cdc_processor      (independent — CDC → SCD2)
+  4. sensor_silver           (independent — clean sensors)
+  5. customer_identity_bridge (depends on step 2 — hub_customer must exist)
+"""
+
+from datetime import datetime, timedelta
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+
+GHOSTKITCHEN_DIR = "/opt/ghostkitchen"
+PYTHON = f"{GHOSTKITCHEN_DIR}/venv/bin/python"
+
+default_args = {
+    "owner": "ghostkitchen",
+    "depends_on_past": False,
+    "retries": 1,
+    "retry_delay": timedelta(minutes=5),
+    "email_on_failure": False,
+}
+
+with DAG(
+    dag_id="dag_bronze_to_silver",
+    default_args=default_args,
+    description="Bronze → Silver: schema alignment, Data Vault load, sensor clean, identity bridge",
+    schedule_interval=None,  # Manual trigger for dev; set to "0 */2 * * *" for prod
+    start_date=datetime(2024, 1, 1),
+    catchup=False,
+    tags=["ghostkitchen", "silver"],
+) as dag:
+
+    order_schema_alignment = BashOperator(
+        task_id="order_schema_alignment",
+        bash_command=(
+            f"cd {GHOSTKITCHEN_DIR} && "
+            f"{PYTHON} -m transformations.bronze_to_silver.order_schema_alignment"
+        ),
+    )
+
+    data_vault_loader = BashOperator(
+        task_id="data_vault_loader",
+        bash_command=(
+            f"cd {GHOSTKITCHEN_DIR} && "
+            f"{PYTHON} -m transformations.bronze_to_silver.data_vault_loader"
+        ),
+    )
+
+    menu_cdc_processor = BashOperator(
+        task_id="menu_cdc_processor",
+        bash_command=(
+            f"cd {GHOSTKITCHEN_DIR} && "
+            f"{PYTHON} -m transformations.bronze_to_silver.menu_cdc_processor"
+        ),
+    )
+
+    sensor_silver = BashOperator(
+        task_id="sensor_silver",
+        bash_command=(
+            f"cd {GHOSTKITCHEN_DIR} && "
+            f"{PYTHON} -m transformations.bronze_to_silver.sensor_to_silver"
+        ),
+    )
+
+    customer_identity_bridge = BashOperator(
+        task_id="customer_identity_bridge",
+        bash_command=(
+            f"cd {GHOSTKITCHEN_DIR} && "
+            f"{PYTHON} -m transformations.identity_resolution.customer_identity_bridge"
+        ),
+    )
+
+    # Dependencies
+    order_schema_alignment >> data_vault_loader >> customer_identity_bridge
+    # menu_cdc_processor and sensor_silver are independent of order flow

--- a/airflow_dags/dag_full_pipeline.py
+++ b/airflow_dags/dag_full_pipeline.py
@@ -1,0 +1,51 @@
+"""
+GhostKitchen: Full Pipeline Airflow DAG
+========================================
+Master DAG that triggers Bronze→Silver then Silver→Gold in sequence.
+This is the end-to-end refresh DAG for production use.
+
+Schedule: daily at 2AM UTC (Silver runs at 2AM, Gold at 4AM via its own DAG).
+For dev: set schedule_interval=None and trigger manually.
+"""
+
+from datetime import datetime, timedelta
+from airflow import DAG
+from airflow.operators.trigger_dagrun import TriggerDagRunOperator
+from airflow.sensors.external_task import ExternalTaskSensor
+
+default_args = {
+    "owner": "ghostkitchen",
+    "depends_on_past": False,
+    "retries": 0,
+    "email_on_failure": False,
+}
+
+with DAG(
+    dag_id="dag_full_pipeline",
+    default_args=default_args,
+    description="Full pipeline: triggers Bronze→Silver then Silver→Gold",
+    schedule_interval=None,  # Manual for dev; set to "0 2 * * *" for prod
+    start_date=datetime(2024, 1, 1),
+    catchup=False,
+    tags=["ghostkitchen", "orchestration"],
+) as dag:
+
+    trigger_bronze_to_silver = TriggerDagRunOperator(
+        task_id="trigger_bronze_to_silver",
+        trigger_dag_id="dag_bronze_to_silver",
+        wait_for_completion=True,
+        poke_interval=30,
+        allowed_states=["success"],
+        failed_states=["failed"],
+    )
+
+    trigger_silver_to_gold = TriggerDagRunOperator(
+        task_id="trigger_silver_to_gold",
+        trigger_dag_id="dag_silver_to_gold",
+        wait_for_completion=True,
+        poke_interval=30,
+        allowed_states=["success"],
+        failed_states=["failed"],
+    )
+
+    trigger_bronze_to_silver >> trigger_silver_to_gold

--- a/airflow_dags/dag_silver_to_gold.py
+++ b/airflow_dags/dag_silver_to_gold.py
@@ -1,0 +1,96 @@
+"""
+GhostKitchen: Silver → Gold Airflow DAG
+========================================
+Builds all Gold dimensions and fact tables in dependency order.
+Schedule: daily at 4AM UTC (set to None for dev — trigger manually).
+
+Task order:
+  Group 1 (no deps):    dim_date, dim_time
+  Group 2 (no deps):    dim_kitchen, dim_brand, dim_delivery_zone
+  Group 3 (dep brand):  dim_menu_item
+  Group 4 (dep hub):    dim_customer
+  Group 5 (dep kitchen+brand): bridge_kitchen_brand
+  Group 6 (dep all dims): fact_order, fact_order_state_history
+  Group 7 (dep kitchen+sensor_silver): fact_sensor_hourly
+  Group 8 (dep fact_order+gps_bronze): fact_delivery_trip
+"""
+
+from datetime import datetime, timedelta
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+
+GHOSTKITCHEN_DIR = "/opt/ghostkitchen"
+PYTHON = f"{GHOSTKITCHEN_DIR}/venv/bin/python"
+
+default_args = {
+    "owner": "ghostkitchen",
+    "depends_on_past": False,
+    "retries": 1,
+    "retry_delay": timedelta(minutes=10),
+    "email_on_failure": False,
+}
+
+
+def spark_task(task_id: str, module: str) -> BashOperator:
+    return BashOperator(
+        task_id=task_id,
+        bash_command=(
+            f"cd {GHOSTKITCHEN_DIR} && "
+            f"{PYTHON} -m {module}"
+        ),
+    )
+
+
+with DAG(
+    dag_id="dag_silver_to_gold",
+    default_args=default_args,
+    description="Silver → Gold: all Gold dimensions and fact tables",
+    schedule_interval=None,  # Manual for dev; set to "0 4 * * *" for prod
+    start_date=datetime(2024, 1, 1),
+    catchup=False,
+    tags=["ghostkitchen", "gold"],
+) as dag:
+
+    # ── Group 1: no dependencies ──────────────────────────────────────────────
+    dim_date = spark_task("dim_date", "transformations.silver_to_gold.dim_date")
+    dim_time = spark_task("dim_time", "transformations.silver_to_gold.dim_time")
+
+    # ── Group 2: no dependencies ──────────────────────────────────────────────
+    dim_kitchen      = spark_task("dim_kitchen",       "transformations.silver_to_gold.dim_kitchen")
+    dim_brand        = spark_task("dim_brand",         "transformations.silver_to_gold.dim_brand")
+    dim_delivery_zone = spark_task("dim_delivery_zone","transformations.silver_to_gold.dim_delivery_zone")
+
+    # ── Group 3: depends on dim_brand ────────────────────────────────────────
+    dim_menu_item = spark_task("dim_menu_item", "transformations.silver_to_gold.dim_menu_item")
+
+    # ── Group 4: depends on Silver hub_customer + identity_bridge ────────────
+    dim_customer = spark_task("dim_customer", "transformations.silver_to_gold.dim_customer")
+
+    # ── Group 5: depends on dim_kitchen + dim_brand ──────────────────────────
+    bridge_kitchen_brand = spark_task(
+        "bridge_kitchen_brand", "transformations.silver_to_gold.bridge_kitchen_brand"
+    )
+
+    # ── Group 6: depends on all dims ─────────────────────────────────────────
+    fact_order = spark_task("fact_order", "transformations.silver_to_gold.fact_order")
+    fact_order_state_history = spark_task(
+        "fact_order_state_history", "transformations.silver_to_gold.fact_order_state_history"
+    )
+
+    # ── Group 7: depends on dim_kitchen + sensor silver ──────────────────────
+    fact_sensor_hourly = spark_task(
+        "fact_sensor_hourly", "transformations.silver_to_gold.fact_sensor_hourly"
+    )
+
+    # ── Group 8: depends on fact_order + GPS Bronze ──────────────────────────
+    fact_delivery_trip = spark_task(
+        "fact_delivery_trip", "transformations.silver_to_gold.fact_delivery_trip"
+    )
+
+    # ── Dependency graph ──────────────────────────────────────────────────────
+    dim_brand >> dim_menu_item
+    [dim_kitchen, dim_brand] >> bridge_kitchen_brand
+    [dim_date, dim_time, dim_kitchen, dim_brand, dim_delivery_zone, dim_customer] >> fact_order
+    [dim_kitchen, fact_order] >> fact_order_state_history
+    dim_kitchen >> fact_sensor_hourly
+    fact_order >> fact_delivery_trip


### PR DESCRIPTION
## Summary
- Add `dag_bronze_to_silver.py`: sequential order_schema_alignment → data_vault_loader → customer_identity_bridge; menu_cdc_processor and sensor_silver run independently
- Add `dag_silver_to_gold.py`: full dependency graph dims → facts; scheduled 04:00 UTC daily
- Add `dag_full_pipeline.py`: TriggerDagRunOperator chain with wait_for_completion=True

## Test plan
- [x] Start Airflow locally (`docker compose up airflow`)
- [x] Trigger `dag_bronze_to_silver` manually — confirm all tasks green
- [x] Trigger `dag_silver_to_gold` manually — confirm dependency order respected
- [x] Trigger `dag_full_pipeline` — confirms end-to-end chain completes

Closes #7