### PR TITLE
Add Great Expectations quality suites and runner

### DIFF
--- a/data_quality/expectations/dim_customer.json
+++ b/data_quality/expectations/dim_customer.json
@@ -1,0 +1,51 @@
+{
+  "expectation_suite_name": "dim_customer",
+  "meta": {
+    "great_expectations_version": "0.18.19",
+    "notes": "SCD2 customer dimension. PII check: email must be hashed in Gold."
+  },
+  "expectations": [
+    {
+      "expectation_type": "expect_column_values_to_be_unique",
+      "kwargs": {"column": "customer_hk"},
+      "meta": {"notes": "One current row per customer."}
+    },
+    {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {"column": "customer_hk"},
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {"column": "email_masked"},
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_not_match_regex",
+      "kwargs": {
+        "column": "email_masked",
+        "regex": "@"
+      },
+      "meta": {
+        "notes": "CRITICAL: email_masked must NOT contain @ — proves it is MD5 hashed, not raw email. Raw email is PII and must never appear in Gold."
+      }
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_between",
+      "kwargs": {
+        "column": "platform_count",
+        "min_value": 1,
+        "max_value": 3
+      },
+      "meta": {"notes": "There are only 3 platforms (uber_eats, doordash, own_app)."}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_in_set",
+      "kwargs": {
+        "column": "is_current",
+        "value_set": [true, false]
+      },
+      "meta": {}
+    }
+  ]
+}

--- a/data_quality/expectations/dim_menu_item.json
+++ b/data_quality/expectations/dim_menu_item.json
@@ -1,0 +1,41 @@
+{
+  "expectation_suite_name": "dim_menu_item",
+  "meta": {
+    "great_expectations_version": "0.18.19",
+    "notes": "SCD2 menu item dimension. One current row per item_id."
+  },
+  "expectations": [
+    {
+      "expectation_type": "expect_column_values_to_be_unique",
+      "kwargs": {"column": "menu_item_key"},
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {"column": "item_id"},
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_between",
+      "kwargs": {
+        "column": "price",
+        "min_value": 0.99,
+        "max_value": 50.0
+      },
+      "meta": {"notes": "Menu items: $0.99 min (sides), $50 max (platters). price column is dollars (price_cents / 100)."}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_in_set",
+      "kwargs": {
+        "column": "is_current",
+        "value_set": [true, false]
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {"column": "valid_from"},
+      "meta": {"notes": "SCD2 effective_start must always be populated."}
+    }
+  ]
+}

--- a/data_quality/expectations/fact_order.json
+++ b/data_quality/expectations/fact_order.json
@@ -1,0 +1,73 @@
+{
+  "expectation_suite_name": "fact_order",
+  "meta": {
+    "great_expectations_version": "0.18.19",
+    "notes": "Grain: one row per order. Checks FK presence, value ranges, platform enum."
+  },
+  "expectations": [
+    {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {"column": "customer_hk"},
+      "meta": {"notes": "Every order must link to a customer."}
+    },
+    {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {"column": "kitchen_key"},
+      "meta": {"notes": "Every order must link to a kitchen."}
+    },
+    {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {"column": "brand_key"},
+      "meta": {"notes": "Every order must link to a brand."}
+    },
+    {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {"column": "date_key"},
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {"column": "time_key"},
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_between",
+      "kwargs": {
+        "column": "order_total_cents",
+        "min_value": 100,
+        "max_value": 100000
+      },
+      "meta": {"notes": "$1 minimum, $1000 maximum order value."}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_between",
+      "kwargs": {
+        "column": "item_count",
+        "min_value": 1,
+        "max_value": 20
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_in_set",
+      "kwargs": {
+        "column": "platform",
+        "value_set": ["uber_eats", "doordash", "own_app"]
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_match_regex",
+      "kwargs": {
+        "column": "date_key",
+        "regex": "^\\d{8}$"
+      },
+      "meta": {"notes": "date_key must be YYYYMMDD format."}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_unique",
+      "kwargs": {"column": "platform_order_id"},
+      "meta": {"notes": "No duplicate orders in the fact table."}
+    }
+  ]
+}

--- a/data_quality/run_quality_checks.py
+++ b/data_quality/run_quality_checks.py
@@ -1,0 +1,132 @@
+"""
+GhostKitchen — Great Expectations Quality Checks
+==================================================
+Loads expectation suites from data_quality/expectations/*.json and validates
+them against live Gold Delta tables using great_expectations.dataset.SparkDFDataset.
+
+Suite files live in:
+    data_quality/expectations/fact_order.json
+    data_quality/expectations/dim_customer.json
+    data_quality/expectations/dim_menu_item.json
+
+Usage:
+    cd ghostkitchen/
+    python -m data_quality.run_quality_checks
+
+Exit codes:
+    0 — all suites passed
+    1 — one or more expectations failed
+"""
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from ingestion.spark_config import get_spark_session
+
+import great_expectations as ge
+from great_expectations.core import ExpectationSuite
+from great_expectations.dataset import SparkDFDataset
+
+GOLD_BASE       = "s3a://ghostkitchen-lakehouse/gold"
+EXPECTATIONS_DIR = os.path.join(os.path.dirname(__file__), "expectations")
+
+# Map suite name → Gold Delta path
+SUITE_TABLE_MAP = {
+    "fact_order":    f"{GOLD_BASE}/fact_order",
+    "dim_customer":  f"{GOLD_BASE}/dim_customer",
+    "dim_menu_item": f"{GOLD_BASE}/dim_menu_item",
+}
+
+
+def load_suite(suite_name: str) -> ExpectationSuite:
+    """Load an expectation suite from the local JSON file."""
+    path = os.path.join(EXPECTATIONS_DIR, f"{suite_name}.json")
+    with open(path) as f:
+        suite_dict = json.load(f)
+    return ExpectationSuite(**suite_dict)
+
+
+def validate_table(spark, suite_name: str, table_path: str) -> dict:
+    """
+    Read a Gold Delta table, wrap it in SparkDFDataset, and run validation.
+    Returns the GE ValidationResult dict.
+    """
+    print(f"\n── Validating: {suite_name} ──────────────────────────────")
+
+    try:
+        df = spark.read.format("delta").load(table_path)
+    except Exception as e:
+        print(f"  ❌  Could not read table at {table_path}: {e}")
+        return {"success": False, "suite": suite_name, "error": str(e)}
+
+    suite  = load_suite(suite_name)
+    ge_df  = SparkDFDataset(df, expectation_suite=suite)
+    result = ge_df.validate(expectation_suite=suite, catch_exceptions=True)
+
+    passed = 0
+    failed = 0
+    for er in result["results"]:
+        exp_type = er["expectation_config"]["expectation_type"]
+        col      = er["expectation_config"]["kwargs"].get("column", "")
+        success  = er["success"]
+        icon     = "✅" if success else "❌"
+
+        detail = ""
+        if not success and er.get("result"):
+            res = er["result"]
+            if "unexpected_count" in res:
+                detail = f"{res['unexpected_count']} unexpected values"
+            elif "observed_value" in res:
+                detail = f"observed={res['observed_value']}"
+
+        label = f"{exp_type}({col})" if col else exp_type
+        print(f"  {icon}  {label}" + (f"  →  {detail}" if detail else ""))
+
+        if success:
+            passed += 1
+        else:
+            failed += 1
+
+    print(f"  Summary: {passed} passed / {failed} failed")
+    return {"success": result["success"], "suite": suite_name,
+            "passed": passed, "failed": failed}
+
+
+def main():
+    print("\n" + "=" * 65)
+    print("  GhostKitchen — Great Expectations Validation")
+    print(f"  Suites: {list(SUITE_TABLE_MAP.keys())}")
+    print("=" * 65)
+
+    spark   = get_spark_session("GhostKitchen-DataQuality")
+    results = []
+
+    for suite_name, table_path in SUITE_TABLE_MAP.items():
+        r = validate_table(spark, suite_name, table_path)
+        results.append(r)
+
+    spark.stop()
+
+    # ── Final summary ─────────────────────────────────────────────────────────
+    total_suites  = len(results)
+    passed_suites = sum(1 for r in results if r.get("success"))
+    failed_suites = total_suites - passed_suites
+
+    print("\n" + "=" * 65)
+    print(f"  Suites passed: {passed_suites}/{total_suites}")
+    if failed_suites:
+        print(f"  FAILED suites:")
+        for r in results:
+            if not r.get("success"):
+                print(f"    ❌  {r['suite']} "
+                      f"({r.get('failed', '?')} expectation(s) failed)")
+    print("=" * 65)
+
+    sys.exit(0 if failed_suites == 0 else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 delta-spark==3.0.0
+great-expectations==0.18.19
 exceptiongroup==1.3.1
 Faker==40.8.0
 importlib_metadata==8.7.1


### PR DESCRIPTION
## Summary
- Add `great-expectations==0.18.19` to requirements.txt
- Add 3 Gold expectation suite JSONs in `data_quality/expectations/`: `fact_order`, `dim_customer`, `dim_menu_item`
- Add `data_quality/run_quality_checks.py`: loads suites, wraps Gold Delta tables in SparkDFDataset, exits 1 on failure
- `dim_customer` suite includes PII guard: `email_masked` must not contain `@`

## Test plan
- [x] `pip install great-expectations==0.18.19` — confirm no conflicts
- [x] Run `python data_quality/run_quality_checks.py` against populated Gold tables — exits 0
- [x] Manually inject a bad row (order_total_cents=0) — confirm exits 1
- [x] Confirm `email_masked` check catches a raw email

Relates to #8 — Gold suites and GE infrastructure complete; Silver layer suites (hub_customer, sat_order_details, identity_bridge) tracked separately in #8