### PR TITLE
Add Gold to PostgreSQL export and Metabase SQL views

### DIFF
--- a/serving/export_gold_to_postgres.py
+++ b/serving/export_gold_to_postgres.py
@@ -1,0 +1,132 @@
+"""
+GhostKitchen — Export Gold Delta Tables → PostgreSQL
+=====================================================
+Reads every Gold Delta table from MinIO and writes it to PostgreSQL
+so that Metabase / Superset can query the Star Schema via standard SQL
+without needing a Spark connector.
+
+Credentials are read from environment variables — never hardcoded.
+
+Environment variables required:
+    POSTGRES_HOST     (default: localhost)
+    POSTGRES_PORT     (default: 5432)
+    POSTGRES_DB       (default: ghostkitchen)
+    POSTGRES_USER     (default: postgres)
+    POSTGRES_PASSWORD (required — no default)
+
+Usage:
+    cd ghostkitchen/
+    POSTGRES_PASSWORD=secret python -m serving.export_gold_to_postgres
+
+    # Export a single table:
+    POSTGRES_PASSWORD=secret python -m serving.export_gold_to_postgres --table fact_order
+
+Dependencies (add to requirements.txt for serving environment):
+    psycopg2-binary
+    sqlalchemy
+"""
+
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from ingestion.spark_config import get_spark_session
+
+GOLD_BASE = "s3a://ghostkitchen-lakehouse/gold"
+
+# Tables exported in dependency order (dims before facts)
+GOLD_TABLES = [
+    "dim_date",
+    "dim_time",
+    "dim_kitchen",
+    "dim_brand",
+    "dim_delivery_zone",
+    "dim_menu_item",
+    "dim_customer",
+    "bridge_kitchen_brand",
+    "fact_order",
+    "fact_order_state_history",
+    "fact_sensor_hourly",
+    "fact_delivery_trip",
+]
+
+
+def get_jdbc_url() -> str:
+    host     = os.environ.get("POSTGRES_HOST", "localhost")
+    port     = os.environ.get("POSTGRES_PORT", "5432")
+    database = os.environ.get("POSTGRES_DB",   "ghostkitchen")
+    return f"jdbc:postgresql://{host}:{port}/{database}"
+
+
+def get_jdbc_properties() -> dict:
+    password = os.environ.get("POSTGRES_PASSWORD")
+    if not password:
+        print("❌  POSTGRES_PASSWORD environment variable is not set.")
+        sys.exit(1)
+
+    return {
+        "user":     os.environ.get("POSTGRES_USER", "postgres"),
+        "password": password,
+        "driver":   "org.postgresql.Driver",
+    }
+
+
+def export_table(spark, table_name: str, jdbc_url: str, jdbc_props: dict):
+    """Read one Gold Delta table and overwrite it in PostgreSQL."""
+    delta_path = f"{GOLD_BASE}/{table_name}"
+    print(f"  Exporting {table_name} ...", end="", flush=True)
+
+    try:
+        df = spark.read.format("delta").load(delta_path)
+        rows = df.count()
+
+        df.write \
+            .jdbc(
+                url=jdbc_url,
+                table=table_name,
+                mode="overwrite",
+                properties=jdbc_props,
+            )
+
+        print(f"  ✅  {rows:,} rows → postgres.{table_name}")
+    except Exception as e:
+        print(f"  ❌  Failed: {e}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Export GhostKitchen Gold Delta tables to PostgreSQL."
+    )
+    parser.add_argument(
+        "--table",
+        help="Export only this table (default: all Gold tables).",
+        default=None,
+    )
+    args = parser.parse_args()
+
+    jdbc_url   = get_jdbc_url()
+    jdbc_props = get_jdbc_properties()
+
+    print(f"\n{'=' * 65}")
+    print(f"  GhostKitchen — Gold → PostgreSQL Export")
+    print(f"  Target: {jdbc_url}")
+    print(f"{'=' * 65}\n")
+
+    spark = get_spark_session("GhostKitchen-GoldExport")
+
+    tables = [args.table] if args.table else GOLD_TABLES
+
+    for table in tables:
+        export_table(spark, table, jdbc_url, jdbc_props)
+
+    spark.stop()
+
+    print(f"\n✅  Export complete: {len(tables)} table(s) written to PostgreSQL.")
+    print("   Run the SQL views in serving/gold_to_metabase_views.sql to create")
+    print("   the Metabase-ready views on top of the exported tables.")
+
+
+if __name__ == "__main__":
+    main()

--- a/serving/gold_to_metabase_views.sql
+++ b/serving/gold_to_metabase_views.sql
@@ -1,0 +1,180 @@
+-- GhostKitchen — Gold Layer SQL Views for Metabase / Superset / Redshift
+-- =========================================================================
+-- These views sit on top of the Gold Delta tables (exported to PostgreSQL
+-- by export_gold_to_postgres.py) and power the seven standard dashboards.
+--
+-- Naming convention: vw_{business_concept}
+-- All monetary values in CENTS unless column name ends in _dollars.
+-- =========================================================================
+
+
+-- ── 1. Revenue by kitchen by day ──────────────────────────────────────────
+CREATE OR REPLACE VIEW vw_revenue_by_kitchen_by_day AS
+SELECT
+    d.full_date                              AS order_date,
+    d.year,
+    d.month,
+    d.day_of_month,
+    d.is_weekend,
+    k.kitchen_id,
+    k.name                                   AS kitchen_name,
+    k.city,
+    k.state,
+    COUNT(*)                                 AS order_count,
+    SUM(fo.order_total_cents)                AS total_revenue_cents,
+    ROUND(SUM(fo.order_total_cents) / 100.0, 2) AS total_revenue_dollars,
+    ROUND(AVG(fo.order_total_cents) / 100.0, 2) AS avg_order_value_dollars,
+    SUM(fo.item_count)                       AS total_items_sold,
+    SUM(CASE WHEN fo.is_cancelled THEN 1 ELSE 0 END) AS cancelled_orders
+FROM fact_order fo
+JOIN dim_date    d  ON fo.date_key    = d.date_key
+JOIN dim_kitchen k  ON fo.kitchen_key = k.kitchen_key
+GROUP BY
+    d.full_date, d.year, d.month, d.day_of_month, d.is_weekend,
+    k.kitchen_id, k.name, k.city, k.state
+ORDER BY d.full_date DESC, total_revenue_cents DESC;
+
+
+-- ── 2. Revenue by brand by day ────────────────────────────────────────────
+CREATE OR REPLACE VIEW vw_revenue_by_brand_by_day AS
+SELECT
+    d.full_date                              AS order_date,
+    d.year,
+    d.month,
+    b.brand_id,
+    b.brand_name,
+    b.cuisine_type,
+    COUNT(*)                                 AS order_count,
+    SUM(fo.order_total_cents)                AS total_revenue_cents,
+    ROUND(SUM(fo.order_total_cents) / 100.0, 2) AS total_revenue_dollars,
+    ROUND(AVG(fo.order_total_cents) / 100.0, 2) AS avg_order_value_dollars,
+    SUM(fo.item_count)                       AS total_items_sold,
+    fo.platform,
+    COUNT(DISTINCT fo.customer_hk)           AS unique_customers
+FROM fact_order fo
+JOIN dim_date  d ON fo.date_key  = d.date_key
+JOIN dim_brand b ON fo.brand_key = b.brand_key
+GROUP BY
+    d.full_date, d.year, d.month,
+    b.brand_id, b.brand_name, b.cuisine_type, fo.platform
+ORDER BY d.full_date DESC, total_revenue_cents DESC;
+
+
+-- ── 3. Average delivery time by zone ─────────────────────────────────────
+-- NOTE: delivery duration comes from fact_delivery_trip (GPS-derived).
+--       We join via order_id to get the zone.
+CREATE OR REPLACE VIEW vw_avg_delivery_time_by_zone AS
+SELECT
+    dz.zone_id,
+    dz.zone_name,
+    dz.city,
+    COUNT(fdt.trip_key)                         AS trip_count,
+    ROUND(AVG(fdt.duration_minutes), 2)         AS avg_duration_minutes,
+    ROUND(MIN(fdt.duration_minutes), 2)         AS min_duration_minutes,
+    ROUND(MAX(fdt.duration_minutes), 2)         AS max_duration_minutes,
+    ROUND(AVG(fdt.distance_km), 3)              AS avg_distance_km,
+    ROUND(AVG(fdt.avg_speed_kmh), 2)            AS avg_speed_kmh
+FROM fact_delivery_trip fdt
+JOIN fact_order          fo ON fdt.order_id = fo.platform_order_id
+JOIN dim_delivery_zone   dz ON fo.zone_key  = dz.zone_key
+WHERE fdt.duration_minutes >= 0
+GROUP BY dz.zone_id, dz.zone_name, dz.city
+ORDER BY avg_duration_minutes ASC;
+
+
+-- ── 4. Multi-platform customers ───────────────────────────────────────────
+CREATE OR REPLACE VIEW vw_multi_platform_customers AS
+SELECT
+    dc.customer_hk,
+    dc.customer_id,
+    dc.email_masked,
+    dc.platform_count,
+    dc.platforms_list,
+    dc.is_multi_platform,
+    dc.first_order_date,
+    COUNT(fo.platform_order_id)              AS total_orders,
+    SUM(fo.order_total_cents)                AS lifetime_value_cents,
+    ROUND(SUM(fo.order_total_cents) / 100.0, 2) AS lifetime_value_dollars
+FROM dim_customer dc
+LEFT JOIN fact_order fo ON dc.customer_hk = fo.customer_hk
+WHERE dc.is_multi_platform = TRUE
+  AND dc.is_current = TRUE
+GROUP BY
+    dc.customer_hk, dc.customer_id, dc.email_masked,
+    dc.platform_count, dc.platforms_list, dc.is_multi_platform,
+    dc.first_order_date
+ORDER BY lifetime_value_cents DESC;
+
+
+-- ── 5. Menu price history for any item ────────────────────────────────────
+-- Point-in-time: use WHERE item_id = 'BB-01' to trace price changes.
+CREATE OR REPLACE VIEW vw_menu_price_history AS
+SELECT
+    dmi.item_id,
+    dmi.item_name,
+    dmi.brand,
+    dmi.category,
+    dmi.price                                AS price_dollars,
+    ROUND(dmi.price * 100)                   AS price_cents,
+    dmi.valid_from                           AS effective_start,
+    dmi.valid_to                             AS effective_end,
+    dmi.is_current,
+    CASE
+        WHEN dmi.valid_to IS NULL THEN 'current'
+        ELSE 'historical'
+    END                                      AS version_status
+FROM dim_menu_item dmi
+ORDER BY dmi.item_id, dmi.valid_from DESC;
+
+
+-- ── 6. Hourly sensor anomaly counts by kitchen ────────────────────────────
+CREATE OR REPLACE VIEW vw_hourly_sensor_anomalies AS
+SELECT
+    k.kitchen_id,
+    k.name                                   AS kitchen_name,
+    k.city,
+    fsh.sensor_type,
+    fsh.zone,
+    DATE(fsh.hour)                           AS sensor_date,
+    EXTRACT(HOUR FROM fsh.hour)              AS sensor_hour,
+    fsh.reading_count,
+    fsh.anomaly_count,
+    ROUND(
+        100.0 * fsh.anomaly_count / NULLIF(fsh.reading_count, 0),
+        2
+    )                                        AS anomaly_rate_pct,
+    fsh.avg_value,
+    fsh.min_value,
+    fsh.max_value
+FROM fact_sensor_hourly fsh
+JOIN dim_kitchen k ON fsh.kitchen_id = k.kitchen_id
+WHERE fsh.anomaly_count > 0
+ORDER BY fsh.anomaly_count DESC, sensor_date DESC;
+
+
+-- ── 7. Top 10 customers by order count ───────────────────────────────────
+CREATE OR REPLACE VIEW vw_top_customers_by_order_count AS
+SELECT
+    dc.customer_hk,
+    dc.customer_id,
+    dc.email_masked,
+    dc.is_multi_platform,
+    dc.platform_count,
+    dc.platforms_list,
+    dc.first_order_date,
+    COUNT(fo.platform_order_id)              AS total_orders,
+    SUM(fo.order_total_cents)                AS lifetime_value_cents,
+    ROUND(SUM(fo.order_total_cents) / 100.0, 2) AS lifetime_value_dollars,
+    ROUND(AVG(fo.order_total_cents) / 100.0, 2) AS avg_order_value_dollars,
+    COUNT(DISTINCT fo.kitchen_key)           AS kitchens_ordered_from,
+    COUNT(DISTINCT fo.brand_key)             AS brands_ordered_from,
+    MAX(fo.order_placed_ts)                  AS last_order_ts
+FROM dim_customer dc
+JOIN fact_order fo ON dc.customer_hk = fo.customer_hk
+WHERE dc.is_current = TRUE
+GROUP BY
+    dc.customer_hk, dc.customer_id, dc.email_masked,
+    dc.is_multi_platform, dc.platform_count, dc.platforms_list,
+    dc.first_order_date
+ORDER BY total_orders DESC
+LIMIT 10;


### PR DESCRIPTION
## Summary
- Add `serving/export_gold_to_postgres.py`: exports all 12 Gold Delta tables to PostgreSQL via Spark JDBC in dependency order; credentials via env vars only; supports `--table` flag for single-table export
- Add `serving/gold_to_metabase_views.sql`: 7 analysis-ready views including `vw_multi_platform_customers`, `vw_revenue_by_kitchen_by_day`, `vw_revenue_by_brand_by_day`, `vw_avg_delivery_time_by_zone`, `vw_menu_price_history`, `vw_hourly_sensor_anomalies`, `vw_top_customers_by_order_count`

## Test plan
- [x] Set `POSTGRES_HOST/PORT/DB/USER/PASSWORD` env vars
- [x] Run `python serving/export_gold_to_postgres.py` — confirm all 12 tables written
- [x] Run `python serving/export_gold_to_postgres.py --table fact_order` — single table export
- [x] Apply `gold_to_metabase_views.sql` in PostgreSQL — confirm all 7 views queryable
- [x] Query `vw_multi_platform_customers` — verify customers with platform_count > 1 appear

Relates to #6 — `vw_multi_platform_customers` view addresses cross-platform visibility; `fact_customer_ltv` aggregation table tracked separately in #6
Relates to #5 — `vw_hourly_sensor_anomalies` view surfaces anomalies from Gold; real-time streaming alert pipeline tracked separately in #5